### PR TITLE
Edit : RG name option to allow provisionning in existing RG

### DIFF
--- a/src/bicep/Makefile
+++ b/src/bicep/Makefile
@@ -1,9 +1,10 @@
-stackName=privatecapps
-location=westeurope
+stackName = privatecapps
+rgName = rgprivatecapps
+location = westeurope
 default: deploy
 
 deploy:
-	@az deployment sub create --template-file main.bicep --location $(location) --parameters stackName=$(stackName) stackLocation=$(location)
+	@az deployment sub create --template-file main.bicep --location $(location) --parameters rgName=$(rgName) stackName=$(stackName) stackLocation=$(location)
 
 clean:
 	@az group delete --resource-group $(stackName) --yes

--- a/src/bicep/main.bicep
+++ b/src/bicep/main.bicep
@@ -1,14 +1,15 @@
 targetScope = 'subscription'
 
+@description('resource group name, will set the destination of the whole stack')
+param rgName string= 'rgprivatecapps'
+
 @description('stack name, will prefix all the ressource deployement names and will be available in all tags')
 param stackName string = 'privatecapps'
 
 @description('stack location')
 param stackLocation string = 'westeurope'
 
-var stackResourceGroupName  = stackName
-
-var keyVaultName = '${stackName}-kvdeploysec'
+var keyVaultName = 'kv-${stackName}'
 
 // network infrastructure
 var stackVNetCIDR = '10.5.0.0/16'
@@ -44,7 +45,7 @@ var lawSharedKeySecretName = 'lawSharedKey'
 
 /** the resource group */
 resource rg 'Microsoft.Resources/resourceGroups@2021-01-01' = {
-  name: stackResourceGroupName
+  name: rgName
   location: stackLocation
   tags: stackTags
 }
@@ -64,7 +65,7 @@ module vnet './modules/vnet.bicep' = {
 
 // kv for storing deployement secrets
 module kv './modules/kv.bicep' = {
-  name: '${stackName}-kvdeploysec'
+  name: keyVaultName
   scope: resourceGroup(rg.name)
   params: {
     kvName: keyVaultName

--- a/src/bicep/main.bicep
+++ b/src/bicep/main.bicep
@@ -87,7 +87,7 @@ module law './modules/law.bicep' = {
   }
 }
 
-// fetch the kv in order to get the Log Abalyics Shared Key
+// fetch the kv in order to get the Log Analytics Shared Key
 resource infraSecretsKV 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
   scope: resourceGroup(rg.name)
   name: keyVaultName


### PR DESCRIPTION
Ease deployment for teams without rg creation rights : 
- Gives the option to set a RG name that is different from the stackName 
- rgName can be empty and will take "rgprivatecapps" as default name 
- Key Vault name has a limitation to 24 characters, basing the name on "kv-{stackname}" to give more space to unique stackname.