### PR TITLE
Makefile and Bicep simplifications - tested with RG contributor, no Sub rights

### DIFF
--- a/src/bicep/Makefile
+++ b/src/bicep/Makefile
@@ -1,7 +1,8 @@
 stackName = privatecapps
 rgName = rgprivatecapps
 location = westeurope
-RESIDS = "none"
+# RESIDS = $(shell az resource list --tag Stack=$(stackName) | jq -r '.[] | select (.resourceGroup=="$(rgName)") | .id' | tr '\n' ' ')
+RESIDS = $(shell az resource list --tag Stack=$(stackName) | jq -r '.[] | select (.resourceGroup=="$(rgName)")| .id' | tr '\n' ' ')
 
 default: deploy
 deploy : deploy-sub
@@ -22,10 +23,17 @@ clean-sub:
 	@az group delete --resource-group $(rgName) --yes
 	
 rg.resource.list:
-	@az resource list --tag Stack=$(stackName) | jq -r '.[] | select (.resourceGroup=="$(rgName)") | .id' | tr '\n' ' ' > rg.resource.list
+	@az resource list --tag Stack="$(stackName)" | jq -r '.[] | select (.resourceGroup=="$(rgName)") | .id' | tr '\n' ' ' > rg.resource.list
 
-clean-rg: rg.resource.list
+clean-test: 
+	@echo $(RESIDS-TEST)
+
+clean-rg-test:
 	@echo "[*] cleaning created resources from resource group $(rgName), this might take a while ..."
-	@$(eval RESIDS=$(shell cat rg.resource.list))
-	@az resource delete d--ids $(RESIDS)
-	@rm -f rg.resource.list
+	@az resource delete --ids $(RESIDS) --verbose
+
+# clean-rg: rg.resource.list
+# 	@echo "[*] cleaning created resources from resource group $(rgName), this might take a while ..."
+# 	@$(eval RESIDS=$(shell cat rg.resource.list))
+# 	@az resource delete --ids $(RESIDS)
+# 	@rm -f rg.resource.list

--- a/src/bicep/Makefile
+++ b/src/bicep/Makefile
@@ -1,39 +1,29 @@
 stackName = privatecapps
 rgName = rgprivatecapps
 location = westeurope
-# RESIDS = $(shell az resource list --tag Stack=$(stackName) | jq -r '.[] | select (.resourceGroup=="$(rgName)") | .id' | tr '\n' ' ')
 RESIDS = $(shell az resource list --tag Stack=$(stackName) | jq -r '.[] | select (.resourceGroup=="$(rgName)")| .id' | tr '\n' ' ')
+# If resource group doesn't exist, or user lacks read rights on it, the following command will return that the resource group does not exist
+# This will trigger below an error at creation time
+rgExists= $(shell (az group exists -g $(rgName)) ||( echo "false" ))	
 
 default: deploy
-deploy : deploy-sub
-clean : clean-sub
-
-deploy-rg:  
-	@echo "[*] deploying to resource group $(rgName) ..."
-	@perl -ne 'print unless /\/\/SUBSTART/../\/\/SUBEND/' main.bicep > main.rg.bicep
-	@az deployment group create --resource-group $(rgName) --template-file main.rg.bicep --parameters stackName=$(stackName) stackLocation=$(location)
-	@rm -f main.rg.bicep
+deploy : deploy-rg
+clean : clean-rg
 
 deploy-sub:
-	@echo "[*] deploying to subscritption in the resource group $(rgName) ..."
-	@az deployment sub create --template-file main.bicep --location $(location) --parameters rgName=$(rgName) stackName=$(stackName) stackLocation=$(location)
+	@echo "[*] deploying to subscription in an existing or newly created resource group $(rgName) ..."
+# If resource group doesn't exist, or user lacks read rights on it, the following command will fail and return an error
+	@if [ $(rgExists) != "true" ]; then az group create --name $(rgName) --location $(location); fi
+	@az deployment group create --resource-group $(rgName) --template-file main.bicep --parameters stackName=$(stackName) stackLocation=$(location)
+
+deploy-rg:
+	@echo "[*] deploying to the existing resource group $(rgName) ..."
+	@az deployment group create --resource-group $(rgName) --template-file main.bicep --parameters stackName=$(stackName) stackLocation=$(location)
 
 clean-sub:
 	@echo "[*] deleting resource group $(rgName), this might take a while ..."
 	@az group delete --resource-group $(rgName) --yes
-	
-rg.resource.list:
-	@az resource list --tag Stack="$(stackName)" | jq -r '.[] | select (.resourceGroup=="$(rgName)") | .id' | tr '\n' ' ' > rg.resource.list
 
-clean-test: 
-	@echo $(RESIDS-TEST)
-
-clean-rg-test:
+clean-rg:
 	@echo "[*] cleaning created resources from resource group $(rgName), this might take a while ..."
 	@az resource delete --ids $(RESIDS) --verbose
-
-# clean-rg: rg.resource.list
-# 	@echo "[*] cleaning created resources from resource group $(rgName), this might take a while ..."
-# 	@$(eval RESIDS=$(shell cat rg.resource.list))
-# 	@az resource delete --ids $(RESIDS)
-# 	@rm -f rg.resource.list

--- a/src/bicep/Makefile
+++ b/src/bicep/Makefile
@@ -1,6 +1,8 @@
 stackName = privatecapps
 rgName = rgprivatecapps
 location = westeurope
+
+# Will store the resource Ids that will be deleted based on the tag et resource group name passed as parameters
 RESIDS = $(shell az resource list --tag Stack=$(stackName) | jq -r '.[] | select (.resourceGroup=="$(rgName)")| .id' | tr '\n' ' ')
 # If resource group doesn't exist, or user lacks read rights on it, the following command will return that the resource group does not exist
 # This will trigger below an error at creation time
@@ -12,7 +14,7 @@ clean : clean-rg
 
 deploy-sub:
 	@echo "[*] deploying to subscription in an existing or newly created resource group $(rgName) ..."
-# If resource group doesn't exist, or user lacks read rights on it, the following command will fail and return an error
+# Fail fast : If user lacks write rights on the subscription, or read rights on target resource group, the following command will fail and return an error (as expected)
 	@if [ $(rgExists) != "true" ]; then az group create --name $(rgName) --location $(location); fi
 	@az deployment group create --resource-group $(rgName) --template-file main.bicep --parameters stackName=$(stackName) stackLocation=$(location)
 

--- a/src/bicep/Makefile
+++ b/src/bicep/Makefile
@@ -9,8 +9,8 @@ RESIDS = $(shell az resource list --tag Stack=$(stackName) | jq -r '.[] | select
 rgExists= $(shell (az group exists -g $(rgName)) ||( echo "false" ))	
 
 default: deploy
-deploy : deploy-rg
-clean : clean-rg
+deploy : deploy-sub
+clean : clean-sub
 
 deploy-sub:
 	@echo "[*] deploying to subscription in an existing or newly created resource group $(rgName) ..."

--- a/src/bicep/main.bicep
+++ b/src/bicep/main.bicep
@@ -167,7 +167,7 @@ module caclient './modules/caenv.bicep' = {
 }
 
 /** Helloer app, will serve the http calls */
-var backendAppName = 'helloer'
+var backendAppName = '${stackName}-helloer'
 module cahelloer './modules/ca.bicep' = {
   name: '${stackName}-ca-helloer'
   //SUBSTART
@@ -206,7 +206,7 @@ module cahelloer './modules/ca.bicep' = {
           }
           {
             name: 'HELLOER_BACKEND_TYPE'
-            value: 'helloer'
+            value: backendAppName
           }
 
         ]
@@ -241,7 +241,7 @@ module cagreeter './modules/ca.bicep' = {
   scope: resourceGroup(rg.name)
   //SUBEND
   params: {
-    caAppName: 'greeter'
+    caAppName: '${stackName}-greeter'
     caAppTags: stackTags
     caAppMinReplicas: 1
     caAppMaxReplicas: 1
@@ -251,7 +251,7 @@ module cagreeter './modules/ca.bicep' = {
     caAppContainers: [
       {
         image: 'docker.io/zlatkoa/pgreeter:1.0.2'
-        name: 'greeter'
+        name: '${stackName}-greeter'
         resources: {
           cpu: 1
           memory: '2.0Gi'


### PR DESCRIPTION
Added some simplifications on the way to generate the resource group (if does not exist) ^
=> If user has no rights at sub level, and tries to create, it will fail as expected
=> Is user has write rights at target rg scope level, deploy-sub and deploy-rg will work as expected
=> left deploy-rg for the moment to avoid the risks of creating a non desired rg as part of the process

Added some prefixes to ACA-Apps and ACA-Env to help with the multiple deployments/regions (testing in same rg) scenarios. 
=> Needs further testings to validate greeter works as expected still.